### PR TITLE
Add podname to async profiler report filename when specified

### DIFF
--- a/k8s-diagnostics-toolbox.sh
+++ b/k8s-diagnostics-toolbox.sh
@@ -193,7 +193,7 @@ function diag_async_profiler() {
             local filename=$(basename -- "$fileparam")
             local extension="${filename##*.}"
             local filename="${filename%.*}"
-            local target_filename="${filename}_$(date +%F-%H%M%S).${extension}"
+            local target_filename="${filename}_${PODNAME}_$(date +%F-%H%M%S).${extension}"
             mv "$ROOT_PATH/$fileparam" "$target_filename"
             _diag_chown_sudo_user "$target_filename"
             echo "$target_filename"


### PR DESCRIPTION
Add podname to async profiler report filename when specified. 

Example usage: 

```
./k8s-diagnostics-toolbox.sh async_profiler broker-3 -e cpu -d 30 1 -f /tmp/profile-cpu.html
```
It will generate: `profile-cpu_broker-3_2022-12-22-124458.html`