### PR TITLE
Update crictl ps command flag (--id -> --name)

### DIFF
--- a/k8s-diagnostics-toolbox.sh
+++ b/k8s-diagnostics-toolbox.sh
@@ -458,7 +458,7 @@ function _diag_find_container() {
       docker ps -q --filter label=io.kubernetes.docker.type=container --filter label=io.kubernetes.pod.name="$PODNAME" | head -n 1
     else
       if [[ "$PODNAME" =~ ^[0-9a-f]+$ ]]; then
-        local containerid=$(diag_crictl ps --id "$PODNAME" -q | head -n 1)
+        local containerid=$(diag_crictl ps --name "$PODNAME" -q | head -n 1)
         if [[ -n "$containerid" ]]; then
           echo "$containerid"
           return 0


### PR DESCRIPTION
For some reason `crictl ps --id` is not working anymore on crictl v1.22.0. 

Running 

```
./k8s-diagnostics-toolbox.sh diag_crictl ps --id pulsar-broker-2
CONTAINER           IMAGE               CREATED             STATE               NAME                ATTEMPT             POD ID
```

I could not find the root cause, but this change (https://github.com/kubernetes-sigs/cri-tools/commit/04f3427f8b804f98b1fc2f53edc283a1896b9120) looks interesting. More investigation would be needed, for now this seems to work.