### PR TITLE
Add more info to async profile report filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ This will record CPU, allocations and locks in JFR format and create a flamegrap
 
 Example: Profile the CPU used by `pulsar-broker-0` for 30 seconds
 ```
-./k8s-diagnostics-toolbox.sh diag_async_profiler pulsar-broker-0 -t -e cpu,lock -d 30 -f /tmp/profile.jfr 1
+./k8s-diagnostics-toolbox.sh async_profiler pulsar-broker-0 -t -e cpu,lock -d 30 -f /tmp/profile.jfr 1
 ```
 This will record CPU and create a flamegraph in JFR format in the toolbox home. The resulting flamegraph file name is 
 ```

--- a/README.md
+++ b/README.md
@@ -76,15 +76,18 @@ Example: Start and stop async-profiler for `pulsar-broker-0`
 sudo ./k8s-diagnostics-toolbox.sh async_profiler_profile pulsar-broker-0 jfr
 ```
 This will record CPU, allocations and locks in JFR format and create a flamegraph in html format.
-The JFR file can be further analysed in [JDK Mission Control](https://adoptium.net/jmc/).
+
 
 Example: Profile the CPU used by `pulsar-broker-0` for 30 seconds
 ```
-./k8s-diagnostics-toolbox.sh diag_async_profiler pulsar-broker-0 -t -e cpu -d 30 -f /tmp/profile.html 1
+./k8s-diagnostics-toolbox.sh diag_async_profiler pulsar-broker-0 -t -e cpu,lock -d 30 -f /tmp/profile.jfr 1
 ```
-This will record CPU and create a flamegraph in html format in the toolbox home. The file can then be analysed in any browser or using [JDK Mission Control](https://adoptium.net/jmc/).
-
+This will record CPU and create a flamegraph in JFR format in the toolbox home. The resulting flamegraph file name is 
+```
+profile_cpu-lock_<docker_image_of_profiled_container>_pulsar-broker-0_<hourMinuteSecond_of_observation>.jfr
+```
 > Note: the file passed to the `diag_async_profiler` via the flag `-f` must be specified as an absolute path.
+JFR files can be further analysed in [JDK Mission Control](https://adoptium.net/jmc/).
 
 ### Running Java Flight Recorder
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,13 @@ sudo ./k8s-diagnostics-toolbox.sh async_profiler_profile pulsar-broker-0 jfr
 This will record CPU, allocations and locks in JFR format and create a flamegraph in html format.
 The JFR file can be further analysed in [JDK Mission Control](https://adoptium.net/jmc/).
 
+Example: Profile the CPU used by `pulsar-broker-0` for 30 seconds
+```
+./k8s-diagnostics-toolbox.sh diag_async_profiler pulsar-broker-0 -t -e cpu -d 30 -f /tmp/profile.html 1
+```
+This will record CPU and create a flamegraph in html format in the toolbox home. The file can then be analysed in any browser or using [JDK Mission Control](https://adoptium.net/jmc/).
+
+> Note: the file passed to the `diag_async_profiler` via the flag `-f` must be specified as an absolute path.
 
 ### Running Java Flight Recorder
 

--- a/README.md
+++ b/README.md
@@ -80,11 +80,11 @@ This will record CPU, allocations and locks in JFR format and create a flamegrap
 
 Example: Profile the CPU used by `pulsar-broker-0` for 30 seconds
 ```
-./k8s-diagnostics-toolbox.sh async_profiler pulsar-broker-0 -t -e cpu,lock -d 30 -f /tmp/profile.jfr 1
+./k8s-diagnostics-toolbox.sh async_profiler pulsar-broker-0 -t -e cpu,lock,alloc -d 30 -f /tmp/profile.jfr 1
 ```
 This will record CPU and create a flamegraph in JFR format in the toolbox home. The resulting flamegraph file name is 
 ```
-profile_cpu-lock_<docker_image_of_profiled_container>_pulsar-broker-0_<hourMinuteSecond_of_observation>.jfr
+profile_cpu-lock-alloc_<docker_image_of_profiled_container>_pulsar-broker-0_<hourMinuteSecond_of_observation>.jfr
 ```
 > Note: the file passed to the `diag_async_profiler` via the flag `-f` must be specified as an absolute path.
 JFR files can be further analysed in [JDK Mission Control](https://adoptium.net/jmc/).

--- a/k8s-diagnostics-toolbox.sh
+++ b/k8s-diagnostics-toolbox.sh
@@ -201,7 +201,7 @@ function diag_async_profiler() {
         fi
         if [[ "${argv[i]}" == "-e" ]]; then
           local nextarg=$((i+1))
-          asyncprofilercommand="${argv[nextarg]}"
+          asyncprofilercommand="${argv[nextarg]/,/-}"
         fi
     done
     if [[ -f "$ROOT_PATH/$fileparam" ]]; then


### PR DESCRIPTION
Add asyncprofiler command and docker image used by the currently profiled container to the name of the flamegraph file.

Example: 
```
./k8s-diagnostics-toolbox.sh diag_async_profiler pulsar-broker-0 -t -e cpu -d 30 -f /tmp/profile.html 1
```
Generates a file following the pattern: 
```
profile_cpu_<docker_image_of_profiled_container>_pulsar-broker-0_<hourMinuteSecond_of_observation>.html
```
The file is generated in the directory containing `k8s-diagnostics-toolbox.sh`.